### PR TITLE
Lore accurate Felinids - Replaces Felinid blood with Felinid mutation toxin

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -4,6 +4,7 @@
 	id = "felinid"
 	say_mod = "meows"
 	limbs_id = "human"
+	exotic_blood = /datum/reagent/mutationtoxin/felinid
 
 	mutant_bodyparts = list("tail_human" = "Cat", "ears" = "Cat", "wings" = "None")
 


### PR DESCRIPTION
## About The Pull Request
This PR makes felinidism contagious via exposure to felinid blood.

This is a code solution to a lore issue. The new lore for felinids is as follwos:
Felinids are no longer born. Adult felinids inject their blood into healthy members of other species causing them to morph into another felinid.

I think this is the best way to represent the felinid community within the lore as OOCly they tend to spread through subliminal brainwashing. Now ICly felinids will need to over many months encourage other players to take some of their blood. I am absolutely certain that not one felinid player would turn someone else into a felinid without their consent.

Spoiler warning
## Why It's Good For The Game
A lore master said that they didn't want to write lore for species reproduction so I made a code solution for felinid reproduction.
image

### Changelog
:cl:
qol: Made felinid lore intresting
/:cl: